### PR TITLE
cron frequency

### DIFF
--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -1,7 +1,7 @@
 name: NVD CVE Update
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/5 * * * *'
 jobs:
   cron:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub Actions Schedule
---
GitHub actions schedule may be unreliable to start a cron on-time. 

- [ ] Seek alternative to deploy updates continuously.
- [ ] seek alternative that is not "broken"